### PR TITLE
Fix potential bug with nuclide densities in Results.export_to_materials

### DIFF
--- a/openmc/deplete/results.py
+++ b/openmc/deplete/results.py
@@ -417,7 +417,16 @@ class Results(list):
             mat_id = str(mat.id)
             if mat_id in result.mat_to_ind:
                 mat.volume = result.volume[mat_id]
+
+                # Change density of all nuclides in material to atom/b-cm
+                atoms_per_barn_cm = mat.get_nuclide_atom_densities()
+                for nuc, value in atoms_per_barn_cm.items():
+                    mat.remove_nuclide(nuc)
+                    mat.add_nuclide(nuc, value)
                 mat.set_density('sum')
+
+                # For nuclides in chain that have cross sections, replace
+                # density in original material with new density from results
                 for nuc in result.nuc_to_ind:
                     if nuc not in available_cross_sections:
                         continue


### PR DESCRIPTION
Looks like the weird micros you were seeing in case 3 were not due to any problem any `IndependentOperator` but rather a bug in `Results.export_to_materials`. With the fix here, case 3 should look a lot better :crossed_fingers: 